### PR TITLE
Login with credentials file & bugfix

### DIFF
--- a/create_obs.py
+++ b/create_obs.py
@@ -113,6 +113,10 @@ if not(os.path.isfile(dargs["file"])):
 # LOAD CONFIG FILE
 loader = yaml.YAML(typ = "rt")
 cfg = loader.load(open(filename, "r"))
+try:
+    credentials = loader.load(open("credentials.yml", "r"))
+except FileNotFoundError:
+    credentials = None
         
 if "fov" in dargs:
     fov = int(dargs["fov"])
@@ -138,8 +142,12 @@ if demo:
     # setup for testing on P2 demo server
     api = p2api.ApiConnection('demo', 52052, "tutorial")
 else:
-    user = input("ESO P2 username: ")
-    password = getpass("ESO P2 password: ")
+    if credentials is None:
+        user = input("ESO P2 username: ")
+        password = getpass("ESO P2 password: ")
+    else:
+        user = credentials["username"]
+        password = credentials["password"]
     api = p2api.ApiConnection('production', user, password)
 
 if "bg" in dargs:

--- a/credentials.yml
+++ b/credentials.yml
@@ -1,0 +1,2 @@
+username: your_username
+password: your_password

--- a/p2Gravity/ob/dualOnOb.py
+++ b/p2Gravity/ob/dualOnOb.py
@@ -40,11 +40,14 @@ class DualOnOb(ObservingBlock):
         dxs = np.array([tpl["SEQ.RELOFF.X"][0] for tpl in self.templates])
         dys = np.array([tpl["SEQ.RELOFF.Y"][0] for tpl in self.templates])
         dsep = np.sqrt(dxs**2 + dys**2)
-        if dsep.max() > 1:
+        if dsep.max() > 1 and dsep.max() < 400:
             dx =  dxs[dsep > 1].mean()
             dy =  dys[dsep > 1].mean()
+        elif dsep.max() >= 400: # acquisition offsets larger than 400 mas cause an error on the instrument
+            dx =  dxs[dsep > 1].mean() / 1000.
+            dy =  dys[dsep > 1].mean() / 1000.
         else:
-            dy,dy = dxs[0],dys[0]
+            dx,dy = dxs[0],dys[0]
         self.acquisition["SEQ.INS.SOBJ.X"] = round(dx, 2)
         self.acquisition["SEQ.INS.SOBJ.Y"] = round(dy, 2)
         # now we need to remove the acq position from the first element of each templates


### PR DESCRIPTION
- Added a credentials file where users can permanently store their P2 username & password in a convenient yet private manner.
- Fixed a bug with the dual-field on-axis acquisition template which (for an unknown reason) does not accept offsets larger than 400 mas separation (although the mode itself is good for separations of up to 600 mas, but only if they are part of a later exposure template).